### PR TITLE
update doc for cosmos DB PostgreSQL extensions install

### DIFF
--- a/code_samples/azure_cosmosdb_postgresql/README.md
+++ b/code_samples/azure_cosmosdb_postgresql/README.md
@@ -28,9 +28,22 @@ Follow the steps to run the code locally.
   
   *Enable extension*
 
-    Vector search in CosmosDb for PostgreSQL is supported via the [pgvector](https://github.com/pgvector/pgvector) extension. To add it to allowlist via Azure Portal, navigate to `Server Parameters`, under `azure.extensions` and select the `VECTOR` parameter. 
+    Vector search in CosmosDb for PostgreSQL is supported via the [pgvector](https://github.com/pgvector/pgvector) extension. And for the Azure Cosmos DB for PostgreSQL Cluster (PostgreSQL version 12 - 16) the pgvector extension is enabled by default.
     
-     Extension details - [how to use Azure CosmosDb PostgreSQL extensions](https://learn.microsoft.com/en-us/azure/cosmos-db/postgresql/reference-extensions). Check if it's correctly added by running `SHOW azure.extensions;`.
+     Extension details - [how to use Azure CosmosDb PostgreSQL extensions](https://learn.microsoft.com/en-us/azure/cosmos-db/postgresql/reference-extensions).
+
+    PostgreSQL extensions must be installed in your database before you can use them.
+
+     ```sql
+     -- list the standard PostgreSQL extensions that are supported on Azure Cosmos DB for PostgreSQL.
+     SELECT * FROM pg_available_extensions;
+
+     -- install vector extension
+     SELECT create_extension('vector');
+
+     -- To remove an extension installed this way, use drop_extension().
+     SELECT create_extension('vector');
+     ```
 
 - Azure OpenAI
   


### PR DESCRIPTION
## Purpose
I noticed that the Server Parameters option is no longer available in the Cosmos DB Settings. Instead, Coordinator node parameters is available but there is no aze.Extensions option either. So I fixed this problem for the MD file.


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type

I have tested different versions of Postgre, found that the vector extension is already enabled in the database by default, and only need to install SQL before use. So I updated the MD file.

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

![image](https://github.com/Azure-Samples/azure-vector-database-samples/assets/36917625/a227c911-4681-431f-9489-23ccfedcc522)
